### PR TITLE
Abort when tests fail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,8 @@ COPY --from=finalimage /DoubleDutch /DoubleDutch
 WORKDIR /DoubleDutch/build
 RUN pip install requests pytest
 COPY tests/test_server.py test_server.py
-RUN pytest | tee /test_results.log 
+RUN pytest
+RUN echo "tests completed" >> /test_results.log
 
 FROM finalimage AS production
 COPY --from=test /test_results.log /test_results.log


### PR DESCRIPTION
Hi @FryingDutch ,

I made a mistake in the Dockerfile. I tried to redirect the result of the `pytest` command to a file called `test_results.log` using [`tee`](https://askubuntu.com/questions/420981/how-do-i-save-terminal-output-to-a-file). 

However, `tee` did not copy the exit code of `pytest`, so when the tests failed, the below command would not result in a build error:
```Dockerfile
RUN pytest | tee /test_results.log
```
